### PR TITLE
エラーハンドルするだけの拡張メソッド追加。Iterator内のyield return のところでタスクを待つ場合に、UnhandledErro...

### DIFF
--- a/IteratorTasks.Extensions/TaskExtensions.cs
+++ b/IteratorTasks.Extensions/TaskExtensions.cs
@@ -104,6 +104,18 @@ namespace IteratorTasks
             if (t.Exception != null && check(t)) throw t.Exception;
         }
 
+        public static Task WithExceptionHandled(this Task t)
+        {
+            t.ContinueWith(_ =>
+            {
+                if (t.Exception != null)
+                {
+                    t.Exception.IsHandled = true;
+                }
+            });
+            return t;
+        }
+
         /// <summary>
         /// 前段のタスクでエラー出てたらそれを伝搬するだけで、実際にはContinueWithしないバージョン。
         /// </summary>


### PR DESCRIPTION
...rに飛ぶのを防ぐために使うやっつけ機能。
