### PR TITLE
IEvent.ObserveOn 追加

### DIFF
--- a/Event.IteratorTasks/Event.IteratorTasks.csproj
+++ b/Event.IteratorTasks/Event.IteratorTasks.csproj
@@ -57,6 +57,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="EventTaskExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Event.IteratorTasks/EventTaskExtensions.cs
+++ b/Event.IteratorTasks/EventTaskExtensions.cs
@@ -1,0 +1,21 @@
+﻿using System.Threading;
+
+namespace System.Events
+{
+    /// <summary>
+    /// <see cref="IEvent{TArg}"/> と <see cref="IteratorTasks.Task"/> つなぎこみ関連拡張メソッド。
+    /// </summary>
+    public static class EventTaskExtensions
+    {
+        public static IEvent<T> ObserveOn<T>(this IEvent<T> e, IteratorTasks.TaskScheduler scheduler)
+        {
+            return Event.Create<T>(handler =>
+                e.Subscribe((sender, x) =>
+                    scheduler.Post(() =>
+                        handler.Invoke(sender, x)
+                    )
+                )
+            );
+        }
+    }
+}


### PR DESCRIPTION
イベントが UI スレッドの外で起こる場合、イベントハンドラーはUIスレッドに戻さないとまずいことがある。それをやるためのメソッド。Rxもどき。